### PR TITLE
fix yarn install before run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ backup-db:
 
 .PHONY: typegen
 typegen:
-	cd server; yarn run typegen:db
+	cd server; yarn install;yarn run typegen:db
 
 .PHONY: start-server
 start-server:


### PR DESCRIPTION
READMEに記載の手順で実行した際、 `yarn install` が必要となったため追記しました